### PR TITLE
[91] Linux Incorrect modelcard-schema Path

### DIFF
--- a/deeplearning-models/CMakeLists.txt
+++ b/deeplearning-models/CMakeLists.txt
@@ -13,11 +13,7 @@ set( SOURCES
 set ( OUTPUTS )
 foreach( source ${SOURCES} )
    set( src "${_SRCDIR}/${source}" )
-   if( CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
-      set( dst "${_DEST}/${TARGET}/${source}" )
-   else()
-      set( dst "${CMAKE_BINARY_DIR}/lib/${TARGET}/${source}" )
-   endif()
+   set( dst "${_DEST}/${TARGET}/${source}" )
 
    add_custom_command(
       DEPENDS

--- a/modules/mod-deep-learning/DeepModel.cpp
+++ b/modules/mod-deep-learning/DeepModel.cpp
@@ -28,7 +28,11 @@ FilePath DeepModel::DLModelsDir()
 
 FilePath DeepModel::BuiltInModulesDir()
 {
-   return FileNames::MkDir( wxFileName( FileNames::BaseDir(), wxT("deeplearning-models") ).GetFullPath() );
+   #if defined(__WXOSX__) || defined(__WXMSW__)
+      return FileNames::MkDir( wxFileName( FileNames::BaseDir(), wxT("deeplearning-models") ).GetFullPath() );
+   #else
+      return FileNames::MkDir( wxFileName( FileNames::ResourcesDir(), wxT("deeplearning-models") ).GetFullPath() );
+   #endif
 }
 
 void DeepModel::LoadResampler()

--- a/modules/mod-deep-learning/DeepModelManager.cpp
+++ b/modules/mod-deep-learning/DeepModelManager.cpp
@@ -43,8 +43,7 @@ DeepModelManager::DeepModelManager() :
       wxFileName(DeepModel::BuiltInModulesDir(), wxT("modelcard-schema.json"))
                   .GetFullPath()
    );
-   wxLogDebug(wxString(schemaPath));
-   wxLogDebug(wxT("test"));
+
    mModelCardSchema = parsers::ParseFile(schemaPath);
 }
 


### PR DESCRIPTION


Resolves: [Linux Incorrect modelcard-schema Path #91 ](https://github.com/audacitorch/audacity/issues/91)

updated cmake since it is no longer needed to set the modules dst path based on platform.

changed linux filepath for model-schema `modules/mod-deep-learning/DeepModel.cpp`, this is platform dependent for now as I cannot test on Mac or on Windows at the moment. 

removed unnecessary logging in `modules/mod-deep-learning/DeepModelManager.cpp`


