### PR TITLE
[90] implimented a simple solution to bug for issue 90

### DIFF
--- a/modules/mod-deep-learning/DeepLearningAnalyzer.cpp
+++ b/modules/mod-deep-learning/DeepLearningAnalyzer.cpp
@@ -198,7 +198,7 @@ void DeepLearningAnalyzer::TensorToLabelTrack
    // check that the output is one dimensional
    if (output.dim() != 1)
       throw ModelException {
-         XO("Labeler model output is not a single track."), ""
+         XO("Model Error: The tensor output by the labeler model is not one dimension."), ""
       };
 
    // create a map of labels to timestamps

--- a/modules/mod-deep-learning/DeepLearningAnalyzer.cpp
+++ b/modules/mod-deep-learning/DeepLearningAnalyzer.cpp
@@ -196,7 +196,10 @@ void DeepLearningAnalyzer::TensorToLabelTrack
    timestamps += tStart;
 
    // check that the output is one dimensional
-   wxASSERT(output.dim() == 1);
+   if (output.dim() != 1)
+      throw ModelException {
+         XO("Labeler model output is not a single track."), ""
+      };
 
    // create a map of labels to timestamps
    std::map<wxString, std::vector<Stamp> > timestampsMap;


### PR DESCRIPTION
Resolves: [issue 90](https://github.com/audacitorch/audacity/issues/90)

this change will resolve issue 90, instead of using `wxASSERT()` to check if the labeler has output of size 1, we directly compare in an if statement and throw a `ModelException` if the output  dim is not equal to 1. 

this solution prevents the app from crashing when there is a miss-match on the output dim, and gives the user information about the crash. 

it appears that `wxASSERT()` is for catching bugs inside of the debug build, and would not resolve this issue in release builds. 
[source](https://docs.wxwidgets.org/3.0/group__group__funcmacro__debug.html#ga204cc264ee560b67e6c6467ba8ffee5f)


