### PR TITLE
[76] using a custom for better `Add from HuggingFace` errors

### DIFF
--- a/modules/mod-deep-learning/ModelManagerPanel.h
+++ b/modules/mod-deep-learning/ModelManagerPanel.h
@@ -57,6 +57,7 @@ private:
 class ModelManagerPanel final : public wxPanelWrapper
 {
    CardFetchedCallback GetCardFetchedCallback();
+   CardFetchedCallback GetNewCardCallback();
 
 public:
    ModelManagerPanel(wxWindow *parent, Effect *effect,


### PR DESCRIPTION
using a custom call back we give users better information about what went wrong when adding a repo from HuggingFace, this solution would crash after multiple attempts without using `BasicUI::ShowErrorDiaglog` or when throwing an excpetion without a custom call back (since `GetCardFetchedCallback` is called when the deep learning effect is initially opened)

Resolves: [issue 76](https://github.com/audacitorch/audacity/issues/76) & [issue 87](https://github.com/audacitorch/audacity/issues/87)

