### PR TITLE
[84] model display names 

### DIFF
--- a/modules/mod-deep-learning/DeepModelManager.cpp
+++ b/modules/mod-deep-learning/DeepModelManager.cpp
@@ -59,7 +59,7 @@ FilePath DeepModelManager::GetRepoDir(ModelCardHolder card) const
 
    FilePath repoDir = FileNames::MkDir( 
       wxFileName(DeepModel::DLModelsDir(),
-                 card->author() + sep + card->name() 
+                 card->author() + sep + card->modelname() 
       ).GetFullPath()
    );
 
@@ -464,7 +464,7 @@ ModelCardHolder DeepModelManager::NewCardFromHuggingFace(const std::string &json
    
    Doc doc = parsers::ParseString(jsonBody);
    card->Deserialize(doc, mModelCardSchema);
-   (*card).name(cardName)
+   (*card).modelname(cardName)
             .author(cardAuthor)
             .local(false)
             .local_path(audacity::ToUTF8(GetRepoDir(card)));

--- a/modules/mod-deep-learning/ModelCard.cpp
+++ b/modules/mod-deep-learning/ModelCard.cpp
@@ -309,12 +309,9 @@ void ModelCard::Deserialize(const Doc& doc, const Doc& schema)
    // these first three fields are not in HF metadata but rather added later,
    // so don't throw if they are not present (empty default values are given)
    
-   m_modelname              = tryGetString( "name",              doc, false).value_or("");
-   std::optional<std::string> displayname = tryGetString( "displayname",              doc, false);
-   if (displayname)
-      m_displayname = displayname.value();
-   else
-      m_displayname = m_modelname;
+   m_modelname         = tryGetString( "modelname",         doc, false).value_or("");
+   
+   m_displayname       = tryGetString( "displayname",       doc, false).value_or("");
 
    m_author            = tryGetString( "author",            doc, false).value_or("");
 

--- a/modules/mod-deep-learning/ModelCard.cpp
+++ b/modules/mod-deep-learning/ModelCard.cpp
@@ -238,9 +238,13 @@ void ModelCard::Serialize(Writer &writer) const
    // are not serialized because they are filled out
    // by the ModelManager when the ModelCard is loaded from disk. 
 
-   // name
-   writer.String("name");
-   writer.String(m_name.c_str());
+   // displayname
+   writer.String("displayname");
+   writer.String(m_displayname.c_str());   
+   
+   // modelname
+   writer.String("modelname");
+   writer.String(m_modelname.c_str());
 
    // author
    writer.String("author");
@@ -304,7 +308,14 @@ void ModelCard::Deserialize(const Doc& doc, const Doc& schema)
 
    // these first three fields are not in HF metadata but rather added later,
    // so don't throw if they are not present (empty default values are given)
-   m_name              = tryGetString( "name",              doc, false).value_or("");
+   
+   m_modelname              = tryGetString( "name",              doc, false).value_or("");
+   std::optional<std::string> displayname = tryGetString( "displayname",              doc, false);
+   if (displayname)
+      m_displayname = displayname.value();
+   else
+      m_displayname = m_modelname;
+
    m_author            = tryGetString( "author",            doc, false).value_or("");
 
    m_long_description  = tryGetString( "long_description",  doc, false).value_or("no long description available");
@@ -326,7 +337,7 @@ void ModelCard::Deserialize(const Doc& doc, const Doc& schema)
 
 std::string ModelCard::GetRepoID() const
 {
-   return this->author() + '/' + this->name();
+   return this->author() + '/' + this->modelname();
 }
 
 // ModelCardCollection implementation

--- a/modules/mod-deep-learning/ModelCard.h
+++ b/modules/mod-deep-learning/ModelCard.h
@@ -77,7 +77,7 @@ public:
    ModelCard() = default;
    ModelCard(const ModelCard&) = default;
 
-   //! returns {author}/{name}
+   //! returns {author}/{m_modelname}
    std::string GetRepoID() const;
 
    //! check if two ModelCards have the same RepoID
@@ -112,8 +112,11 @@ public:
    std::string local_path() const { return m_local_path; }
    ModelCard &local_path(const std::string& path) { m_local_path = path; return *this;}
 
-   std::string name() const { return m_name; }
-   ModelCard &name(const std::string &name) { m_name = name; return *this;}
+   std::string displayname() const { return m_displayname; }
+   ModelCard &displayname(const std::string &displayname) { m_displayname = displayname; return *this;}
+
+   std::string modelname() const { return m_modelname; }
+   ModelCard &modelname(const std::string &modelname) { m_modelname = modelname; return *this;}
 
    std::string author() const { return m_author; }
    ModelCard &author(const std::string &author) { m_author = author; return *this;}
@@ -146,7 +149,8 @@ public:
    ModelCard &model_size(size_t model_size) { m_model_size = model_size; return *this;}
 
 private:
-   std::string m_name {""};
+   std::string m_displayname {""};
+   std::string m_modelname {""};
    std::string m_author {""};
    std::string m_long_description {""};
    std::string m_short_description {""};

--- a/modules/mod-deep-learning/ModelCardPanel.cpp
+++ b/modules/mod-deep-learning/ModelCardPanel.cpp
@@ -131,7 +131,11 @@ void ModelCardPanel::PopulateNameAndAuthor(ShuttleGui &S)
    // S.StartHorizontalLay(wxALIGN_LEFT, true);
    S.StartMultiColumn(2, wxALIGN_LEFT);
    {
-      mModelName = S.AddVariableText(Verbatim(mCard->displayname()),
+      wxString displayname = mCard->displayname();
+      if (displayname.empty())
+         displayname = mCard->modelname();
+
+      mModelName = S.AddVariableText(Verbatim(displayname),
                                        false, wxLEFT);
       mModelName->SetFont(wxFont(wxFontInfo().Bold()));
 

--- a/modules/mod-deep-learning/ModelCardPanel.cpp
+++ b/modules/mod-deep-learning/ModelCardPanel.cpp
@@ -131,7 +131,7 @@ void ModelCardPanel::PopulateNameAndAuthor(ShuttleGui &S)
    // S.StartHorizontalLay(wxALIGN_LEFT, true);
    S.StartMultiColumn(2, wxALIGN_LEFT);
    {
-      mModelName = S.AddVariableText(Verbatim(mCard->name()),
+      mModelName = S.AddVariableText(Verbatim(mCard->displayname()),
                                        false, wxLEFT);
       mModelName->SetFont(wxFont(wxFontInfo().Bold()));
 


### PR DESCRIPTION
Resolves: [issue 84](https://github.com/audacitorch/audacity/issues/84)

the changes in this PR allow for devlopers to give an optional parameter in their metadata called "displayname", which will be the name that appears in the model manager. we still keep track of the "modelname" since this is repo name on hugging face. 
