### PR TITLE
temporary fix to a linker error on windows

### DIFF
--- a/src/effects/Effect.cpp
+++ b/src/effects/Effect.cpp
@@ -129,14 +129,14 @@ bool Effect::SupportsAutomation() const
    return true;
 }
 
-std::shared_ptr<EffectInstance> StatefulEffect::MakeInstance() const
-{
-   // Cheat with const-cast to return an object that calls through to
-   // non-const methods of a stateful effect.
-   // Stateless effects should override this function and be really const
-   // correct.
-   return std::make_shared<Instance>(const_cast<StatefulEffect&>(*this));
-}
+// std::shared_ptr<EffectInstance> StatefulEffect::MakeInstance() const
+// {
+//    // Cheat with const-cast to return an object that calls through to
+//    // non-const methods of a stateful effect.
+//    // Stateless effects should override this function and be really const
+//    // correct.
+//    return std::make_shared<Instance>(const_cast<StatefulEffect&>(*this));
+// }
 
 const EffectParameterMethods &Effect::Parameters() const
 {

--- a/src/effects/Effect.h
+++ b/src/effects/Effect.h
@@ -361,7 +361,13 @@ public:
       SampleCount GetLatency(
          const EffectSettings &settings, double sampleRate) const override;
    };
-   std::shared_ptr<EffectInstance> MakeInstance() const override;
+   std::shared_ptr<EffectInstance> MakeInstance() const override {
+      // Cheat with const-cast to return an object that calls through to
+      // non-const methods of a stateful effect.
+      // Stateless effects should override this function and be really const
+      // correct.
+      return std::make_shared<Instance>(const_cast<StatefulEffect&>(*this));
+   };
 };
 
 // FIXME:


### PR DESCRIPTION
This is a temporary fix for a linker error we're running into on windows. When building mod-deep-learning the windows linker seems to be unable to link to the definition of StatefulEffect::MakeInstanceif the function is defined in the Effect.cpp file. Moving the definition to the same place as the declaration (i.e. Effect.h) fixes the linker error, but the whole situation is fishy. The linker IS successfully linking the rest of Effect.h, but why not this specific function?