### PR TITLE
[107] set checking for updates to false, and removed the install update

### DIFF
--- a/libraries/lib-preferences/Prefs.cpp
+++ b/libraries/lib-preferences/Prefs.cpp
@@ -64,7 +64,7 @@
 #include "Observer.h"
 
 BoolSetting DefaultUpdatesCheckingFlag{
-    L"/Update/DefaultUpdatesChecking", true };
+    L"/Update/DefaultUpdatesChecking", false };
 
 std::unique_ptr<FileConfig> ugPrefs {};
 

--- a/src/update/UpdatePopupDialog.cpp
+++ b/src/update/UpdatePopupDialog.cpp
@@ -53,7 +53,6 @@ UpdatePopupDialog::UpdatePopupDialog (wxWindow* parent, const VersionPatch& vers
             S.Prop(1).AddSpace(1, 0, 1);
 
             S.Id (wxID_NO).AddButton (XC ("&Skip", "update dialog"));
-            S.Id (wxID_YES).AddButton (XC("&Install update", "update dialog"));
 
             S.SetBorder (5);
         }


### PR DESCRIPTION


Resolves: [issue 107](https://github.com/audacitorch/audacity/issues/107)

this change will remove the ability to install updates , and sets the dialog box for updates to not come up by default. 
