### PR TITLE
[106] remove preview button in deep learning effect

### DIFF
--- a/modules/mod-deep-learning/DeepLearningEffectBase.cpp
+++ b/modules/mod-deep-learning/DeepLearningEffectBase.cpp
@@ -29,7 +29,7 @@
 
 DeepLearningEffectBase::DeepLearningEffectBase()
 {
-   EnablePreview(false);
+   SetBatchProcessing();
 }
 
 bool DeepLearningEffectBase::Init()
@@ -41,6 +41,7 @@ bool DeepLearningEffectBase::Init()
       
       // try loading the model (if available)
       mActiveModel = std::make_shared<ActiveModel>();
+      
       return true;
    }
    catch (const InvalidModelCardDocument &e)
@@ -49,6 +50,7 @@ bool DeepLearningEffectBase::Init()
       wxICON_ERROR);
       return false;
    }
+
 }
 
 void DeepLearningEffectBase::End()
@@ -346,5 +348,6 @@ std::unique_ptr<EffectUIValidator> DeepLearningEffectBase::PopulateOrExchange(Sh
    S.EndVerticalLay();
 
    mActiveModel->SetModel(*this);
+
    return nullptr;
 }


### PR DESCRIPTION
Resolves: [issue 106](https://github.com/audacitorch/audacity/issues/106)

this code uses the `SetBatchProcessing()` function from the `Effect()` class, to set itself as a batch processing effect. after testing and reviewing the code i think this is the simplest way to remove the preview button without modifying code outside of our scope (which may have unintended effects on other audio processing effects)