### PR TITLE
[109] backwards compatibility for older model card metadata

### DIFF
--- a/modules/mod-deep-learning/ModelCard.cpp
+++ b/modules/mod-deep-learning/ModelCard.cpp
@@ -310,6 +310,8 @@ void ModelCard::Deserialize(const Doc& doc, const Doc& schema)
    // so don't throw if they are not present (empty default values are given)
    
    m_modelname         = tryGetString( "modelname",         doc, false).value_or("");
+   if (m_modelname.empty())
+      m_modelname      = tryGetString( "name",              doc, false).value_or(""); // backward compatible for older audacitorch models
    
    m_displayname       = tryGetString( "displayname",       doc, false).value_or("");
 


### PR DESCRIPTION
Resolves: [issue 109](https://github.com/audacitorch/audacity/issues/109)

this code will check for the `name` field in the absence of the new `modelname` field. this will make older cards  installed on older versions of audacitroch compatible with the new form. 

the only thing I'd like to possibly change in the future is that we don't deserialize the metadata after initial installation, so the field will always be `name` and not `modelname`. 