### PR TITLE
[113] save last model selected

### DIFF
--- a/modules/mod-deep-learning/DeepLearningEffectBase.cpp
+++ b/modules/mod-deep-learning/DeepLearningEffectBase.cpp
@@ -63,7 +63,12 @@ void DeepLearningEffectBase::End()
       {
          if (manager.IsInstalling(card))
             manager.CancelInstall(card);
-      }
+      } 
+
+      // save the selected model
+      std::string activeModelId = mActiveModel->GetModel()->GetCard()->GetRepoID();
+      wxConfigBase* config = wxConfigBase::Get();
+      config->Write(wxT("SelectedModel"), wxString::FromUTF8(activeModelId.c_str()));
 
       // release model (may still be active in thread)
       mActiveModel->GetModel()->Offload();
@@ -347,7 +352,22 @@ std::unique_ptr<EffectUIValidator> DeepLearningEffectBase::PopulateOrExchange(Sh
    }
    S.EndVerticalLay();
 
-   mActiveModel->SetModel(*this);
+   wxString presetModelNameTemp;
+   wxConfigBase* config = wxConfigBase::Get();
+   config->Read(wxT("SelectedModel"), &presetModelNameTemp);
+
+   std::string presetModelName(presetModelNameTemp);
+   
+   try 
+   {
+      ModelCardHolder presetModel = manager.FetchCard(presetModelName);
+      mActiveModel->SetModel(*this, presetModel);
+   }
+   catch (ModelManagerException &e) 
+   {
+      wxLogError(wxString(e.what()));
+      wxLogDebug(wxString(e.what()));
+   }
 
    return nullptr;
 }

--- a/modules/mod-deep-learning/ModelManagerPanel.cpp
+++ b/modules/mod-deep-learning/ModelManagerPanel.cpp
@@ -172,6 +172,25 @@ void ModelManagerPanel::FetchCards()
    // prioritize local cards first
    manager.FetchLocalCards(onCardFetched);
    manager.FetchHuggingFaceCards(onCardFetched);
+
+   // set the last used card as the active card 
+   // grab the last used model with wx presets 
+   wxString presetModelNameTemp;
+   wxConfigBase* config = wxConfigBase::Get();
+   config->Read(wxT("SelectedModel"), &presetModelNameTemp);
+
+   std::string presetModelName(presetModelNameTemp);
+   
+   try 
+   {
+      ModelCardHolder presetModel = manager.FetchCard(presetModelName);
+      mActiveModel->SetModel(*mEffect, presetModel);
+   }
+   catch (ModelManagerException &e) 
+   {
+      wxLogError(wxString(e.what()));
+      wxLogDebug(wxString(e.what()));
+   }
    
 }
 


### PR DESCRIPTION
Resolves: [issue 113](https://github.com/audacitorch/audacity/issues/113)

currently this will set the active model to the last used, but it gets written over when the ui fully loads